### PR TITLE
Fix conditionals to display the name of the venue

### DIFF
--- a/.vuepress/components/Event/Content.vue
+++ b/.vuepress/components/Event/Content.vue
@@ -22,7 +22,7 @@
       <DateTime/>
     </div>
 
-    <div id="address" v-if="data.address">
+    <div id="address" v-if="data.venue || data.address">
       <h2 v-if="Array.isArray(data.address)">Venues</h2>
       <h2 v-else>Venue</h2>
       <MapLink/>

--- a/.vuepress/components/Event/MapLink.vue
+++ b/.vuepress/components/Event/MapLink.vue
@@ -11,7 +11,7 @@
         {{ venue.name }}<br/>
       </span>
 
-      <ExternalLink
+      <ExternalLink v-if="venue.address"
         :url="'https://www.google.com/maps/place/' + venue.address"
         :caption="venue.address"
         :indicator="'true'"
@@ -36,7 +36,7 @@ export default {
           count++
           return {
             name: venue,
-            address: addresses[count]
+            address: addresses[count] || null
           }
         })
       }


### PR DESCRIPTION
The name of the venue was hidden if no address was specified. This change
address an edge case where the venue name should be displayed as 'TBA' when,
obviously, the address doesn't exist.